### PR TITLE
fix: add go mod download

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Download Go Modules
+        run: go mod download
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:


### PR DESCRIPTION
Adds go mod download to resolve dependency errors on golang linting

Resolves [TECH-98](https://swamphacks.atlassian.net/browse/TECH-98?atlOrigin=eyJpIjoiZWIzOTA0ZThkNDNiNDg4Mzg3YmZkNWJlYmEzZWE0ZTQiLCJwIjoiaiJ9)