### PR TITLE
TECH-86: Display swagger/openAPI reference to the reference page in docs

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,0 +1,210 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/apps/docs/mkdocs.yml
+++ b/apps/docs/mkdocs.yml
@@ -18,7 +18,6 @@ theme:
     - content.action.edit
 plugins:
   - search
-  - swagger-ui-tag
 copyright: >
   Copyright &copy; 2025 SwampHacks
 
@@ -50,7 +49,7 @@ nav:
   - API:
       - Overview: api/index.md
       - Installation: api/installation.md
-      - Reference: api/reference.md
+      - OpenAPI: 'https://core.apidocumentation.com/guide/swamphacks-core-api'
   - Discord Bot:
       - Overview: discord-bot/index.md
       - Installation: discord-bot/installation.md

--- a/apps/docs/mkdocs.yml
+++ b/apps/docs/mkdocs.yml
@@ -18,6 +18,7 @@ theme:
     - content.action.edit
 plugins:
   - search
+  - swagger-ui-tag
 copyright: >
   Copyright &copy; 2025 SwampHacks
 

--- a/apps/docs/requirements.txt
+++ b/apps/docs/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs
 mkdocs-material
 pymdown-extensions
-mkdocs-swagger-ui-tag

--- a/apps/docs/requirements.txt
+++ b/apps/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocs-material
 pymdown-extensions
+mkdocs-swagger-ui-tag

--- a/apps/docs/src/api/reference.md
+++ b/apps/docs/src/api/reference.md
@@ -1,1 +1,0 @@
-TODO: Render /shared/openapi/swagger.yaml

--- a/apps/docs/src/docs/installation.md
+++ b/apps/docs/src/docs/installation.md
@@ -1,5 +1,7 @@
 # Gettings Started
 
+## Normal setup
+
 1. Install [mkdocs](https://www.mkdocs.org/user-guide/installation/)
 1. Install the python packages listed in core/apps/docs/requirements.txt
 1. Run:
@@ -10,6 +12,24 @@ mkdocs serve
 
 !!! warning
     If the site does not generate because there is still missing dependancies, you can find them using [mkdocs-get-deps](https://github.com/mkdocs/get-deps)
+
+## For linux distributions which do not package python packages through pip
+
+This includes Arch Linux.
+
+1. Run
+```bash
+python -m venv env
+source env/bin/activate
+```
+1. Install packages
+```bash
+pip install -r requirements.txt
+```
+1. Run with
+```bash
+mkdocs serve
+```
 
 ---
 


### PR DESCRIPTION
## Description
Add rendering for OpenAPI yaml file in mkdocs.

## Linked Jira Ticket
Link Jira ticket here. [TECH-86](https://swamphacks.atlassian.net/browse/TECH-86)

## Type of Change
Delete irrelevant options:
- New feature (non-breaking change)

## Checklist
- [X] My code follows the project's style guidelines
- [X] I have commented on complex parts of the code
- [X] I have updated documentation if necessary
- [ ] I have updated or added tests to cover my changes
- [X] I have updated the OpenAPI YAML or other API schema files if applicable

## Additional Notes
<!--
Screenshots and notes would be appreciated!
-->
