### PR TITLE
Fix oauth cookie `secure` to false in development

### DIFF
--- a/apps/web/src/lib/auth/services/oauth.ts
+++ b/apps/web/src/lib/auth/services/oauth.ts
@@ -37,7 +37,7 @@ export function _oauthSignIn<T extends AuthConfig>(config: T) {
     Cookies.set("sh_auth_nonce", state.nonce, {
       path: "/",
       sameSite: "lax",
-      secure: true,
+      secure: import.meta.env.DEV ? false : true,
     });
 
     const params = createOAuthRequestParams(


### PR DESCRIPTION
## Description
Change the oauth cookie's `secure` property to false in development so it works on http.


## Type of Change
Bug fix (non-breaking change)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have commented on complex parts of the code
- [x] I have updated documentation if necessary
- [x] I have updated or added tests to cover my changes
- [x] I have updated the OpenAPI YAML or other API schema files if applicable

