### PR TITLE
Hotfix: allow general access api routes to not require auth

### DIFF
--- a/apps/api/internal/api/api.go
+++ b/apps/api/internal/api/api.go
@@ -118,7 +118,6 @@ func (api *API) setupRoutes(mw *mw.Middleware) {
 
 		// Event-specific routes
 		r.Route("/{eventId}", func(r chi.Router) {
-			r.Use(mw.Auth.RequireAuth)
 
 			// General access
 			r.Get("/", api.Handlers.Event.GetEventByID)

--- a/apps/web/src/features/PlatformAdmin/EventManager/hooks/useAdminEvents.ts
+++ b/apps/web/src/features/PlatformAdmin/EventManager/hooks/useAdminEvents.ts
@@ -9,7 +9,7 @@ type Events =
 
 export async function fetchEvents(): Promise<Events> {
   const result = await api
-    .get<Events>("events?include_unpublished=true")
+    .get<Events>("events?scope=all")
     .json();
   console.log(result);
   return result;


### PR DESCRIPTION
Coming Soon Page cannot collect emails without allowing access to this section of the api.