### PR TITLE
add the existing email routes and handler to the API

### DIFF
--- a/apps/api/internal/api/api.go
+++ b/apps/api/internal/api/api.go
@@ -133,6 +133,9 @@ func Run() {
 	hackathon.RegisterRoutes(hackathonHandler, huma.NewGroup(api, "/hackathon"), mw)
 
 	emailService := email.NewEmailService(hackathonRepo, userRepo, taskQueueClient, sesClient, r2Client, logger, config)
+	emailHandler := email.NewHandler(emailService, logger)
+	email.RegisterRoutes(emailHandler, huma.NewGroup(api, "/email"), mw)
+
 	batService := bat.NewBatService(applicationRepo, hackathonRepo, userRepo, batRunsRepo, emailService, txm, taskQueueClient, nil, config, logger)
 	applicationService := application.NewService(applicationRepo, userRepo, hackathonRepo, txm, r2Client, &config.CoreBuckets, nil, emailService, batService, config, logger)
 	applicationHandler := application.NewHandler(applicationService, batService, config, logger)


### PR DESCRIPTION
## Description

This wires the existing email API endpoints located in apps/api/internal/domains/email/http.go (lines 14 - 58) into the main API router locaed in apps/api/internal/api/api.go.

The email handlerrs and routes were already implemented, but were not registered in the main API router. 


## Type of Change

- Bug fix (non-breaking change)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have commented on complex parts of the code (the change was not complex)
- [x] I have updated documentation if necessary
- [ ] I have updated or added tests to cover my changes
- [x] I have updated the OpenAPI YAML or other API schema files if applicable

## Additional Notes

Previously, the existing email handlers and routes were not reachable in the main api router, and as a result, they did not appear in the OpenAPI docs. This PR adds the existing email handlers into the main api router.

This change allows these endpoints to be reached:
<img width="1133" height="247" alt="image" src="https://github.com/user-attachments/assets/0d5a9b2d-f3ef-4738-8201-9546580145b1" />
